### PR TITLE
don't force users to have a GitHub account and to copy their public SSH key

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "xpas"]
 	path = xpas
-	url = https://github.com:phylo42/xpas.git
+	url = https://github.com/phylo42/xpas.git
 [submodule "strasser"]
 	path = strasser
-	url = https://github.com:nromashchenko/strasser.git
+	url = https://github.com/nromashchenko/strasser.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "xpas"]
 	path = xpas
-	url = git@github.com:phylo42/xpas.git
+	url = https://github.com:phylo42/xpas.git
 [submodule "strasser"]
 	path = strasser
-	url = git@github.com:nromashchenko/strasser.git
+	url = https://github.com:nromashchenko/strasser.git


### PR DESCRIPTION
using `https` rather than the `git` protocol makes it easier to clone your repository.